### PR TITLE
require mosquitto at startup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -16,6 +16,12 @@ wb-mqtt-serial (1.40.4) stable; urgency=medium
 
  -- Attila Door <a.door@wirenboard.ru>  Mon, 2 Apr 2018 11:58:45 +0300
 
+wb-mqtt-serial (1.40.3) stable; urgency=medium
+
+  * require mosquitto at startup
+
+ -- Attila Door <a.door@wirenboard.ru>  Wed, 18 Apr 2018 11:27:45 +0300
+
 wb-mqtt-serial (1.40.2) stable; urgency=medium
 
   * TCP port: detect socket close

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (1.41.1) stable; urgency=medium
+
+  * require mosquitto at startup
+
+ -- Attila Door <a.door@wirenboard.ru>  Thu, 10 May 2018 16:27:45 +0300
+
 wb-mqtt-serial (1.41) stable; urgency=medium
 
   * Fixes WB-MAP6S template
@@ -15,12 +21,6 @@ wb-mqtt-serial (1.40.4) stable; urgency=medium
   * add mir2 json template
 
  -- Attila Door <a.door@wirenboard.ru>  Mon, 2 Apr 2018 11:58:45 +0300
-
-wb-mqtt-serial (1.40.3) stable; urgency=medium
-
-  * require mosquitto at startup
-
- -- Attila Door <a.door@wirenboard.ru>  Wed, 18 Apr 2018 11:27:45 +0300
 
 wb-mqtt-serial (1.40.2) stable; urgency=medium
 

--- a/debian/wb-mqtt-serial.init
+++ b/debian/wb-mqtt-serial.init
@@ -3,7 +3,7 @@
 # Provides:          wb-mqtt-serial
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6
-# Required-Start: $remote_fs
+# Required-Start: $remote_fs mosquitto
 # Required-Stop: $remote_fs
 # Short-Description: MQTT Driver for serial devices
 # Description:       MQTT Driver for serial devices


### PR DESCRIPTION
1.40.4 is the latest version in the changelog but 1.40.3 was missing because it was in another pull request which hasn't been merged yet, so i added 1.40.3 version to this one. 