### PR TITLE
prevent infinite waiting for devicereply

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-serial (1.50.2) stable; urgency=medium
+
+  * default value for response_timeout_ms is 500 ms
+
+ -- Evgeny Boger <boger@contactless.ru>  Mon, 06 May 2019 20:06:49 +0300
+
 wb-mqtt-serial (1.50.1) stable; urgency=medium
 
   * add start dependency from wb-hwconf-manager

--- a/wb-mqtt-serial.schema.json
+++ b/wb-mqtt-serial.schema.json
@@ -89,7 +89,7 @@
           "title": "Response timeout (ms)",
           "description": "Zero means no timeout. If not set, the default timeout (500ms) is used.",
           "minimum": 0,
-          "default": 0,
+          "default": 500,
           "propertyOrder": 6
         },
         "guard_interval_us": {
@@ -178,7 +178,7 @@
           "title": "Response timeout (ms)",
           "description": "Zero means no timeout. If not set, the default timeout (500ms) is used.",
           "minimum": 0,
-          "default": 0,
+          "default": 500,
           "propertyOrder": 5
         },
         "guard_interval_us": {


### PR DESCRIPTION
set default value for response_timeout_ms to 500 ms