### PR TITLE
add AccessLevel parsing from json

### DIFF
--- a/serial_config.cpp
+++ b/serial_config.cpp
@@ -440,6 +440,8 @@ void TConfigParser::LoadDeviceTemplatableConfigPart(PDeviceConfig device_config,
         device_config->Stride = GetInt(device_data, "stride");
     if (device_data.isMember("shift"))
         device_config->Shift = GetInt(device_data, "shift");
+    if (device_data.isMember("access_level"))
+        device_config->AccessLevel = GetInt(device_data, "access_level")
 }
 
 int TConfigParser::ToInt(const Json::Value& v, const string& title)


### PR DESCRIPTION
Сейчас Милур всегда подключается под учётной записью администратора, в моей конфигурации это приводит к тому, что периодически на счётчик отсылается команда сброса до заводских настроек (помимо Милура у меня на этой шине ещё несколько устройств).

Кажется было бы удобно, если бы можно было руками выставлять нужный уровень доступа в конфиге.

P.S. Что интересно — в самом конфиге уже давно можно выставлять access_level, но в коде это значение не обрабатывается